### PR TITLE
Se cierran archivos y se libera la memoria

### DIFF
--- a/tiny_md.c
+++ b/tiny_md.c
@@ -98,5 +98,14 @@ int main()
     printf("# Tiempo simulado = %f [fs]\n", t * 1.6);
     printf("# ns/day = %f\n", (1.6e-6 * t) / elapsed * 86400);
     //                       ^1.6 fs -> ns       ^sec -> day
+
+    // Cierre de archivos
+    fclose(file_thermo);
+    fclose(file_xyz);
+
+    // Liberacion de memoria
+    free(rxyz);
+    free(fxyz);
+    free(vxyz);
     return 0;
 }

--- a/viz.c
+++ b/viz.c
@@ -295,5 +295,10 @@ int main(int argc, char** argv)
 
     glutMainLoop();
 
+    // Liberacion de memoria
+    free(rxyz);
+    free(fxyz);
+    free(vxyz);
+
     exit(0);
 }


### PR DESCRIPTION
Se cierran los archivos utilizados en tiny_md.c y se libera la memoria de los arreglos rxyz, fxyz y vxyz en los archivos tiny_md.c y viz.c